### PR TITLE
Add timeout to the user program run.

### DIFF
--- a/evaluator/Dockerfile
+++ b/evaluator/Dockerfile
@@ -3,7 +3,9 @@ FROM rust:alpine
 
 RUN apk --no-cache add ca-certificates musl-dev
 WORKDIR /rust/app/
-COPY . .
+COPY src/ src/
+COPY Cargo.lock .
+COPY Cargo.toml .
 RUN cargo build --release
 
 

--- a/evaluator/images/lua/evaluate.sh
+++ b/evaluator/images/lua/evaluate.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 
+TIMEOUT_EXIT_CODE=137
+
 cd /eval_env &&
 # Run the actual code as non-root user
 adduser -D evaluator &&
-sudo -u evaluator lua5.1 /usr/bin/evaluate.lua source.lua > stdout.txt 2> stderr.txt
+timeout -s KILL ${EVALUATOR_TIMEOUT:-5} sudo -u evaluator lua5.1 /usr/bin/evaluate.lua source.lua > stdout.txt 2> stderr.txt
+if [ $? -eq ${TIMEOUT_EXIT_CODE} ]; then
+    echo "The program timeouted"
+    echo "The program timeouted" > stderr.txt
+fi

--- a/evaluator/src/main.rs
+++ b/evaluator/src/main.rs
@@ -20,6 +20,7 @@ const EVAL_FOLDER: &str = "eval_env";
 const MEMORY_LIMIT_MB: usize = 128;
 const CPUS_LIMIT: f64 = 0.25;
 const PIDS_LIMIT: usize = 32;
+const MAX_STRING_OUTPUT_LENGTH: usize = 10000;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 enum Language {
@@ -91,8 +92,8 @@ fn run_lua(folder: &str) -> Result<ResponsePayload> {
     let program_stderr = fs::read_to_string(format!("/www/app/sources/lua/{}/stderr.txt", folder)).expect("Unable to read stdout");
 
     Ok(ResponsePayload {
-        stdout: program_stdout,
-        stderr: program_stderr,
+        stdout: program_stdout[..std::cmp::min(MAX_STRING_OUTPUT_LENGTH, program_stdout.len())].to_string(),
+        stderr: program_stderr[..std::cmp::min(MAX_STRING_OUTPUT_LENGTH, program_stderr.len())].to_string(),
     })
 }
 

--- a/integration_tests/evaluator_tests/test_eval.py
+++ b/integration_tests/evaluator_tests/test_eval.py
@@ -34,7 +34,6 @@ print(fact(0))
     response = requests.post(EVALUATOR_ADDRESS, json=payload)
     assert response.status_code == 200
     values = response.json()
-    print(values)
     assert values["stdout"] == '120\n1\n'
     assert values["stderr"] == ''
 
@@ -47,7 +46,6 @@ print(x())
     response = requests.post(EVALUATOR_ADDRESS, json=payload)
     assert response.status_code == 200
     values = response.json()
-    print(values)
     assert values["stdout"] == ''
     assert values["stderr"] == 'source.lua:2: attempt to call global \'x\' (a nil value)'
 
@@ -61,6 +59,17 @@ print(fact(5))
     response = requests.post(EVALUATOR_ADDRESS, json=payload)
     assert response.status_code == 200
     values = response.json()
-    print(values)
     assert values["stdout"] == ''
     assert values["stderr"] == "source.lua:2: '=' expected near 'fact'"
+
+
+def test_eval_timeout1():
+    code = """
+while 1 < 2 do end
+"""
+    payload = generate_lua(code)
+    response = requests.post(EVALUATOR_ADDRESS, json=payload)
+    assert response.status_code == 200
+    values = response.json()
+    assert values["stdout"] == ''
+    assert values["stderr"] == "The program timeouted\n"

--- a/website/src/static/css/style.css
+++ b/website/src/static/css/style.css
@@ -13,6 +13,7 @@
     width: 300px;
     border: 1px solid black;
     color: gray;
+    overflow: auto;
 }
 
 #code-view {

--- a/website/src/website.py
+++ b/website/src/website.py
@@ -16,8 +16,6 @@ from models import db, User, Article, Category
 from forms import LoginForm, ArticleForm
 from auth import admin, JWT_SECRET, JWT_COOKIE
 
-from markupsafe import escape
-
 import requests
 import jwt
 
@@ -64,6 +62,9 @@ with app.app_context():
 def create_test_db():
     salt = gen_salt(32)
     hashed_password = generate_password_hash(salt + "password", method='sha256')
+
+    if User.query.filter_by(username='admin').first() is not None:
+        return
     new_user = User(username='admin', password=hashed_password,
                     salt=salt, email='filip.gregor98@gmail.com', is_admin=1)
     db.session.add(new_user)


### PR DESCRIPTION
The user program is now timeouted when running longer than 5 seconds. The value is set from environment variable, and is expected to be configurable. The timeout command is used for this.

Also, some minor changes were made, like limiting the stderr and stdout size to 10kb and adding overflow to the stdout/err boxes.

Closes #7 