### PR TITLE
feat: add Racket.

### DIFF
--- a/evaluator/Dockerfile
+++ b/evaluator/Dockerfile
@@ -31,29 +31,21 @@ RUN git clone https://github.com/google/nsjail.git /nsjail/ && \
     git checkout 3.4 && \
     make
 
-# ====== GCC build image ======
-FROM debian:bookworm-slim as gcc-builder
-
-WORKDIR /opt/evaluator/
-
-COPY ./scripts/setup_cpp.sh ./scripts/setup_cpp.sh
-
-RUN ./scripts/setup_cpp.sh
-
 # ====== Lua build image ======
-FROM debian:bookworm-slim as lua-builder
+FROM gcc:13.2-bookworm as lua-builder
 
 WORKDIR /opt/evaluator/
-
-RUN apt-get update && apt-get install -y \
-    wget \
-    make \
-    gcc \
-    libreadline-dev
     
-COPY ./scripts ./scripts
+COPY ./scripts/setup_lua.sh ./scripts/setup_lua.sh
 
-RUN ./scripts/setup.sh
+RUN ./scripts/setup_lua.sh
+
+# ====== Racket build image ======
+FROM gcc:13.2-bookworm as racket-builder
+
+COPY ./scripts/setup_racket.sh ./scripts/setup_racket.sh
+
+RUN ./scripts/setup_racket.sh
 
 # ====== Runtime image ======
 FROM debian:bookworm-slim
@@ -82,7 +74,8 @@ COPY --from=builder /rust/app/target/release/evaluator bin/evaluator
 COPY --from=nsjail-builder /nsjail/nsjail bin/nsjail
 
 # compilers and interpreters
-COPY --from=lua-builder /opt/evaluator/compilers /opt/evaluator/compilers
+COPY --from=lua-builder /opt/evaluator/compilers/lua /opt/evaluator/compilers/lua
+COPY --from=racket-builder /opt/evaluator/compilers/racket /opt/evaluator/compilers/racket
 
 
 COPY config/ config/

--- a/evaluator/config/config.yaml
+++ b/evaluator/config/config.yaml
@@ -38,13 +38,6 @@
   commands:
   - "${EXECUTOR} ${EXECUTOR_ARGS} ${SOURCE_FILE} ${SOURCE_ARGS}"
 
-- name: racket
-  executors:
-  - name: racket-bookworm
-    path: /usr/bin/racket
-  commands:
-  - "${EXECUTOR} ${EXECUTOR_ARGS} ${SOURCE_FILE} ${SOURCE_ARGS}"
-
 #- name: haskell
 #  compilers:
 #  - name: ghc-bookworm
@@ -72,3 +65,11 @@
     path: /usr/bin/bash
   commands:
   - "PATH='/bin:/usr/bin' ${EXECUTOR} ${SOURCE_FILE} ${SOURCE_ARGS}"
+
+- name: racket
+  executors:
+  - name: racket-v8.11.1
+    path: /opt/evaluator/compilers/racket/racket-v8.11.1/racket/bin/racket
+  commands:
+    - cp ${SOURCE_FILE} source.rkt
+    - ${EXECUTOR} source.rkt ${SOURCE_ARGS}

--- a/evaluator/scripts/setup.sh
+++ b/evaluator/scripts/setup.sh
@@ -1,4 +1,0 @@
-#!/bin/bash -e
-
-# setup languages
-/opt/evaluator/scripts/setup_lua.sh

--- a/evaluator/scripts/setup_racket.sh
+++ b/evaluator/scripts/setup_racket.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -ev
+
+setup_racket_version() {
+    cd /tmp
+    git clone https://github.com/racket/racket.git
+    cd racket
+    git checkout "${1}"
+    make base -j 4
+    mkdir -p "/opt/evaluator/compilers/racket/racket-${1}"
+    cp -r /tmp/racket/racket "/opt/evaluator/compilers/racket/racket-${1}"
+    rm "/opt/evaluator/compilers/racket/racket-${1}/"{src,man,doc} -rf
+}
+
+setup_racket_version "v8.11.1"

--- a/integration_tests/evaluator_tests/test_racket.py
+++ b/integration_tests/evaluator_tests/test_racket.py
@@ -3,15 +3,15 @@ import requests
 EVALUATOR_ADDRESS = "http://evaluator:7800/api/v1/evaluate"
 
 def generate_racket(code: str):
-    return {"language": "racket", "code": code}
+    return {"language": "racket", "code": code, "executor": "racket-v8.11.1"}
 
-# def test_simple_racket():
-#     payload = generate_racket("""
-# #lang racket
-# (display "Hello, World!\\n")
-# """)
-#     response = requests.post(EVALUATOR_ADDRESS, json=payload)
-#     assert response.status_code == 200
-#     values = response.json()
-#     assert values["stdout"] == "Hello, World!\n"
-#     assert values["stderr"] == ""
+def test_simple_racket():
+    payload = generate_racket("""
+#lang racket
+(display "Hello, World!\\n")
+""")
+    response = requests.post(EVALUATOR_ADDRESS, json=payload)
+    assert response.status_code == 200
+    values = response.json()
+    assert values["stdout"] == "Hello, World!\n"
+    assert values["stderr"] == ""

--- a/website/src/routes/code/+page.svelte
+++ b/website/src/routes/code/+page.svelte
@@ -46,7 +46,13 @@
 			text: 'Python 3',
 			executors: ['python3-bookworm']
 		},
-		// racket: { name: 'racket', server_name: 'racket', editor_name: 'scheme', text: 'Racket', executors: ["racket-bookworm"] },
+		racket: {
+			name: 'racket',
+			server_name: 'racket',
+			editor_name: 'scheme',
+			text: 'Racket',
+			executors: ['racket-v8.11.1']
+		},
 		bash: {
 			name: 'bash',
 			server_name: 'bash',


### PR DESCRIPTION
Add Racket to interpreted languages. Racket is, similarly to lua, built from source. However, Racket build takes a very long time. As it is part of evaluator build, the evaluator now builds **significantly** longer, and this is something that we will have to fix in the future. Maybe by building these images before hand and just pulling them from repository?