### PR TITLE
fix: add cgroupns=host to compose evaluator.

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -40,6 +40,7 @@ services:
       start_period: 10s
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup
+    cgroup: host
 
   statserver:
     build: statserver


### PR DESCRIPTION
There was a problem running on a cgroupv2 (arch) host. For more, see https://github.com/google/nsjail/issues/196.